### PR TITLE
Fixed: broken publish task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 ext {
 	pluginId = 'digital.fino.build.gradle-maven-auth'
-	pluginVersion = '4.1.1'
+	pluginVersion = '4.1.2'
 }
 
 group = 'digital.fino.build'


### PR DESCRIPTION
Fixed: ClassNotFoundException in org.hibernate.build.publish.auth.maven.PublishingRepoHandler:36
Fixed: Support of plugins.id apply false and apply plugin (for external gradle scripts).
Changed: Moved publishing extension detection into afterEvaluate phase.
(tested with Gradle 9.3)